### PR TITLE
Fix error ambiguous trainer class name

### DIFF
--- a/OmniEvent/evaluation/utils.py
+++ b/OmniEvent/evaluation/utils.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import List, Dict, Union, Tuple
 from transformers import PreTrainedTokenizer
 
-from ..trainer import Trainer
+from ..trainer import EETrainer
 from ..trainer_seq2seq import Seq2SeqTrainer
 from ..arguments import DataArguments, ModelArguments, TrainingArguments
 from ..input_engineering.seq2seq_processor import extract_argument
@@ -26,7 +26,7 @@ from .convert_format import (
 logger = logging.getLogger(__name__)
 
 
-def dump_preds(trainer: Union[Trainer, Seq2SeqTrainer],
+def dump_preds(trainer: Union[EETrainer, Seq2SeqTrainer],
                tokenizer: PreTrainedTokenizer,
                data_class: type,
                output_dir: Union[str,Path],
@@ -174,7 +174,7 @@ def get_pred_mrc(logits: np.array,
     return final_preds
 
 
-def predict(trainer: Union[Trainer, Seq2SeqTrainer],
+def predict(trainer: Union[EETrainer, Seq2SeqTrainer],
             tokenizer: PreTrainedTokenizer,
             data_class: type,
             data_args: DataArguments,
@@ -296,7 +296,7 @@ def get_sub_files(input_test_file: str,
     return output_test_files
 
 
-def predict_ed(trainer: Union[Trainer, Seq2SeqTrainer],
+def predict_ed(trainer: Union[EETrainer, Seq2SeqTrainer],
                tokenizer: PreTrainedTokenizer,
                data_class: type,
                data_args,
@@ -337,7 +337,7 @@ def predict_ed(trainer: Union[Trainer, Seq2SeqTrainer],
     return logits, labels, metrics, dataset
 
 
-def predict_sub_ed(trainer: Union[Trainer, Seq2SeqTrainer],
+def predict_sub_ed(trainer: Union[EETrainer, Seq2SeqTrainer],
                    tokenizer: PreTrainedTokenizer,
                    data_class: type,
                    data_args: DataArguments,
@@ -393,7 +393,7 @@ def predict_sub_ed(trainer: Union[Trainer, Seq2SeqTrainer],
     return logits, labels, metrics, dataset
 
 
-def predict_eae(trainer: Union[Trainer, Seq2SeqTrainer],
+def predict_eae(trainer: Union[EETrainer, Seq2SeqTrainer],
                 tokenizer: PreTrainedTokenizer,
                 data_class: type,
                 data_args: DataArguments,
@@ -433,7 +433,7 @@ def predict_eae(trainer: Union[Trainer, Seq2SeqTrainer],
     return logits, labels, metrics, test_dataset
 
 
-def predict_sub_eae(trainer: Union[Trainer, Seq2SeqTrainer],
+def predict_sub_eae(trainer: Union[EETrainer, Seq2SeqTrainer],
                     tokenizer: PreTrainedTokenizer,
                     data_class: type,
                     data_args: DataArguments,

--- a/OmniEvent/trainer.py
+++ b/OmniEvent/trainer.py
@@ -42,7 +42,7 @@ if is_torch_tpu_available():
 logger = logging.getLogger(__name__)
 
 
-class Trainer(Trainer):
+class EETrainer(Trainer):
     """Trainer for event extraction.
 
     Trainer for event extraction, training the model based on the given dataset. The trainer predicts the labels,

--- a/OmniEvent/trainer_seq2seq.py
+++ b/OmniEvent/trainer_seq2seq.py
@@ -23,7 +23,7 @@ from transformers.trainer_seq2seq import (
     is_deepspeed_zero3_enabled,
     PredictionOutput
 )
-from .trainer import Trainer
+from .trainer import EETrainer
 from .model.constraint_decoding import get_constraint_decoder
 from .model.label_smoother_sum import SumLabelSmoother
 
@@ -31,7 +31,7 @@ from .model.label_smoother_sum import SumLabelSmoother
 logger = logging.getLogger(__name__)
 
 
-class Seq2SeqTrainer(Trainer):
+class Seq2SeqTrainer(EETrainer):
     """
     Trainer for event extraction based on the Sequence-to-Sequence (Seq2Seq) paradigm.
 

--- a/examples/EAE/mrc.py
+++ b/examples/EAE/mrc.py
@@ -20,7 +20,7 @@ from OmniEvent.evaluation.dump_result import get_duee_submission_mrc
 from OmniEvent.evaluation.convert_format import get_argument_extraction_mrc
 from OmniEvent.evaluation.utils import predict, get_pred_mrc
 
-from OmniEvent.trainer import Trainer
+from OmniEvent.trainer import EETrainer
 
 # argument parser
 parser = ArgumentParser((ModelArguments, DataArguments, TrainingArguments))
@@ -91,7 +91,7 @@ eval_dataset = data_class(data_args, tokenizer, data_args.validation_file, data_
 training_args.data_for_evaluation = eval_dataset.get_data_for_evaluation()
 
 # Trainer 
-trainer = Trainer(
+trainer = EETrainer(
     args=training_args,
     model=model,
     train_dataset=train_dataset,

--- a/examples/EAE/sequence_labeling.py
+++ b/examples/EAE/sequence_labeling.py
@@ -22,7 +22,7 @@ from OmniEvent.evaluation.convert_format import get_argument_extraction_sl
 from OmniEvent.evaluation.utils import predict
 
 from OmniEvent.input_engineering.input_utils import get_bio_labels
-from OmniEvent.trainer import Trainer
+from OmniEvent.trainer import EETrainer
 
 
 # argument parser
@@ -100,7 +100,7 @@ eval_dataset = data_class(data_args, tokenizer, data_args.validation_file, data_
 training_args.data_for_evaluation = eval_dataset.get_data_for_evaluation()
 
 # Trainer 
-trainer = Trainer(
+trainer = EETrainer(
     args=training_args,
     model=model,
     train_dataset=train_dataset,

--- a/examples/EAE/token_classification.py
+++ b/examples/EAE/token_classification.py
@@ -18,7 +18,7 @@ from OmniEvent.backbone.backbone import get_backbone
 from OmniEvent.evaluation.metric import compute_F1
 from OmniEvent.evaluation.utils import predict
 
-from OmniEvent.trainer import Trainer
+from OmniEvent.trainer import EETrainer
 
 # argument parser
 parser = ArgumentParser((ModelArguments, DataArguments, TrainingArguments))
@@ -101,7 +101,7 @@ eval_dataset = data_class(data_args, tokenizer, data_args.validation_file, data_
 training_args.data_for_evaluation = eval_dataset.get_data_for_evaluation()
 
 # Trainer 
-trainer = Trainer(
+trainer = EETrainer(
     args=training_args,
     model=model,
     train_dataset=train_dataset,

--- a/examples/ED/mrc.py
+++ b/examples/ED/mrc.py
@@ -20,7 +20,7 @@ from OmniEvent.evaluation.convert_format import get_trigger_detection_mrc
 from OmniEvent.evaluation.dump_result import get_leven_submission_sl, get_maven_submission_sl
 
 from OmniEvent.input_engineering.input_utils import get_bio_labels
-from OmniEvent.trainer import Trainer
+from OmniEvent.trainer import EETrainer
 
 # argument parser
 parser = ArgumentParser((ModelArguments, DataArguments, TrainingArguments))
@@ -84,7 +84,7 @@ train_dataset = data_class(data_args, tokenizer, data_args.train_file)
 eval_dataset = data_class(data_args, tokenizer, data_args.validation_file)
 
 # Trainer 
-trainer = Trainer(
+trainer = EETrainer(
     args=training_args,
     model=model,
     train_dataset=train_dataset,

--- a/examples/ED/sequence_labeling.py
+++ b/examples/ED/sequence_labeling.py
@@ -20,7 +20,7 @@ from OmniEvent.evaluation.convert_format import get_trigger_detection_sl
 from OmniEvent.evaluation.dump_result import get_leven_submission_sl, get_maven_submission_sl
 
 from OmniEvent.input_engineering.input_utils import get_bio_labels
-from OmniEvent.trainer import Trainer
+from OmniEvent.trainer import EETrainer
 
 # argument parser
 parser = ArgumentParser((ModelArguments, DataArguments, TrainingArguments))
@@ -86,7 +86,7 @@ train_dataset = data_class(data_args, tokenizer, data_args.train_file)
 eval_dataset = data_class(data_args, tokenizer, data_args.validation_file)
 
 # Trainer 
-trainer = Trainer(
+trainer = EETrainer(
     args=training_args,
     model=model,
     train_dataset=train_dataset,

--- a/examples/ED/token_classification.py
+++ b/examples/ED/token_classification.py
@@ -19,7 +19,7 @@ from OmniEvent.evaluation.metric import compute_F1
 from OmniEvent.evaluation.utils import predict, dump_preds
 from OmniEvent.evaluation.dump_result import get_leven_submission, get_maven_submission
 
-from OmniEvent.trainer import Trainer
+from OmniEvent.trainer import EETrainer
 
 # argument parser
 parser = ArgumentParser((ModelArguments, DataArguments, TrainingArguments))
@@ -92,7 +92,7 @@ train_dataset = data_class(data_args, tokenizer, data_args.train_file)
 eval_dataset = data_class(data_args, tokenizer, data_args.validation_file)
 
 # Trainer 
-trainer = Trainer(
+trainer = EETrainer(
     args=training_args,
     model=model,
     train_dataset=train_dataset,


### PR DESCRIPTION
# 1. Description

The Trainer class definied in both of OmniEvent and Transformers lib, so this cause ambiguous error when this class is called.

# 2. Solution

Rename the Trainer class name in OmniEvent with the new name `EETrainer`.